### PR TITLE
updating class Dispatcher

### DIFF
--- a/src/lib/core/Dispatcher.php
+++ b/src/lib/core/Dispatcher.php
@@ -85,9 +85,9 @@ class Dispatcher
 
           } 
 
-          direct_page('404.php', 404);  
-
         }
+
+        direct_page('404.php', 404);  
 
       }
 


### PR DESCRIPTION
Updating class Dispatcher -- to avoid 404 message when user visit detailed post, user cannot read entirely because it directly redirect to 404 page. 